### PR TITLE
Nuevo fichero palabras.txt de donde coger las palabras

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .PHONY: all $(MAKECMDGOALS)
 
 run:
-	docker run --rm --volume `pwd`:/opt/app --env PYTHON_PATH=/opt/app -w /opt/app python:3.6-slim python3 main.py words.txt yes
+	docker run --rm --volume `pwd`:/opt/app --env PYTHON_PATH=/opt/app -w /opt/app python:3.6-slim python3 main.py palabras.txt yes

--- a/palabras.txt
+++ b/palabras.txt
@@ -1,0 +1,5 @@
+orden
+cable
+mesa
+persona
+pelota


### PR DESCRIPTION
Funcionalidad:
▸	Añadir un fichero de ejemplo, palabras.txt, que incluya varias palabras desordenadas, una por línea, y modificar el Makefile para que use el nombre del fichero como parámetro de línea de comandos.